### PR TITLE
Don't create the entropy device if it doesn't exist

### DIFF
--- a/pollen.go
+++ b/pollen.go
@@ -68,7 +68,7 @@ func main() {
 	}
 
 	var err error
-	dev, err = os.Create(os.Args[3])
+	dev, err = os.OpenFile(os.Args[3], os.O_RDWR, 0)
 	if err != nil {
 		fatalf("Cannot open device: %s\n", err)
 	}


### PR DESCRIPTION
This is a bug.
