### PR TITLE
Use flags rather than positional arguments

### DIFF
--- a/debian/pollen.default
+++ b/debian/pollen.default
@@ -1,12 +1,12 @@
-# HTTP_PORT is the http port on which the pollen server should listen and respond.
+# HTTP_ADDR is the http address on which the pollen server should listen and respond.
 # Note that these connections will not be encrypted
-# Default: 80
-HTTP_PORT="80"
+# Default: :80
+HTTP_ADDR=":80"
 
-# HTTPS_PORT is the https port on which the pollen server should listen and respond.
+# HTTPS_ADDR is the https address on which the pollen server should listen and respond.
 # Note that these connections will be encrypted using TLS
-# Default: 443
-HTTPS_PORT="443"
+# Default: :443
+HTTPS_PORT=":443"
 
 # DEVICE is the source of randomness for entropy donated to the pool,
 # and the destination for received and whitened entropy.

--- a/debian/pollen.upstart
+++ b/debian/pollen.upstart
@@ -14,14 +14,10 @@ script
 	. /etc/default/pollen
 	# Ensure our device exists, and is a character device, before starting our server
 	if [ -c "$DEVICE" ]; then
-		if [ -n "$HTTP_PORT" ] && [ -n "$HTTPS_PORT" ]; then
-			exec pollen $HTTP_PORT $HTTPS_PORT $DEVICE
-		elif [ -n "$HTTP_PORT" ] && [ -z "$HTTPS_PORT" ]; then
-			exec pollen $HTTP_PORT 0 $DEVICE
-		elif [ -z "$HTTP_PORT" ] && [ -n "$HTTPS_PORT" ]; then
-			exec pollen 0 $HTTPS_PORT $DEVICE
+		if [ -n "$BYTES" ] then
+			exec pollen -http-port=$HTTP_PORT -https-port=$HTTPS_PORT -device=$DEVICE -bytes=$BYTES
 		else
-			exec true
+			exec pollen -http-port=$HTTP_PORT -https-port=$HTTPS_PORT -device=$DEVICE
 		fi
 	fi
 end script

--- a/pollen.8
+++ b/pollen.8
@@ -3,17 +3,17 @@
 \fBpollen\fP \- an Entropy-as-a-Service web server
 
 .SH SYNOPSIS
-\fBpollen\fP HTTP_PORT HTTPS_PORT DEVICE
+\fBpollen\fP [OPTION]...
 
 .SH OPTIONS
 
-\fBHTTP_PORT\fP - the http port on which to listen and serve clear text responses; use 0 to disable; default is 80
+\fB-http-addr\fP - the HTTP address:port on which to listen and serve cleartext responses; use "" to disable; default is ":80"
 
-\fBHTTPS_PORT\fP - the https port on which to listen and serve encrypted, TLS responses; use 0 to disable; default is 443
+\fB-https-addr\fP - the HTTPS address:port on which to listen and serve encrypted, TLS responses; use "" to disable; default is ":443"
 
-\fBDEVICE\FP - the device to use for reading and writing random data; default is \fI/dev/urandom\fP
+\fB-device\fP - the device to use for reading and writing random data; default is \fI/dev/urandom\fP
 
-\fBNOTE: All of these must be specified!!!\fP
+\fB-bytes\fP - the size, in bytes, to transmit and receive each time to peers or neighbors listening in the pool; default is 64
 
 .SH DESCRIPTION
 \fBpollen\fP is an Entropy-as-a-Service web server, providing random seeds over a TLS encrypted connection.

--- a/pollen.go
+++ b/pollen.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"crypto/sha512"
+	"flag"
 	"fmt"
 	"io"
 	"log/syslog"
@@ -31,12 +32,13 @@ import (
 )
 
 var (
+	httpAddr  = flag.String("http-addr", ":80", "The HTTP address:port on which to listen")
+	httpsAddr = flag.String("https-addr", ":443", "The HTTPS address:port on which to listen")
+	device    = flag.String("device", "/dev/urandom", "The device to use for reading and writing random data")
+	size      = flag.Int("bytes", 64, "The size in bytes to transmit and receive each time")
+
 	log *syslog.Writer
 	dev *os.File
-)
-
-const (
-	DefaultSize = 64
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -45,9 +47,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	challengeResponse := checksum.Sum(nil)
 	dev.Write(challengeResponse)
 	log.Info(fmt.Sprintf("Server received challenge from [%s, %s] at [%v]", r.RemoteAddr, r.UserAgent(), time.Now().UnixNano()))
-	data := make([]byte, DefaultSize)
-	io.ReadAtLeast(dev, data, DefaultSize)
-	checksum.Write(data[:DefaultSize])
+	data := make([]byte, *size)
+	io.ReadAtLeast(dev, data, *size)
+	checksum.Write(data[:*size])
 	seed := checksum.Sum(nil)
 	fmt.Fprintf(w, "%x\n%x\n", challengeResponse, seed)
 	log.Info(fmt.Sprintf("Server sent response to [%s, %s] at [%v]", r.RemoteAddr, r.UserAgent(), time.Now().UnixNano()))
@@ -63,24 +65,23 @@ func init() {
 }
 
 func main() {
-	if len(os.Args) != 4 {
-		fatalf("Usage: %s HTTP_PORT HTTPS_PORT DEVICE\n", os.Args[0])
+	flag.Parse()
+	if *httpAddr == "" && *httpsAddr == "" {
+		fatal("Nothing to do if http and https are both disabled")
 	}
 
 	var err error
-	dev, err = os.OpenFile(os.Args[3], os.O_RDWR, 0)
+	dev, err = os.OpenFile(*device, os.O_RDWR, 0)
 	if err != nil {
 		fatalf("Cannot open device: %s\n", err)
 	}
 	defer dev.Close()
 
 	http.HandleFunc("/", handler)
-	httpAddr := fmt.Sprintf(":%s", os.Args[1])
-	httpsAddr := fmt.Sprintf(":%s", os.Args[2])
 	go func() {
-		fatal(http.ListenAndServe(httpAddr, nil))
+		fatal(http.ListenAndServe(*httpAddr, nil))
 	}()
-	fatal(http.ListenAndServeTLS(httpsAddr, "/etc/pollen/cert.pem", "/etc/pollen/key.pem", nil))
+	fatal(http.ListenAndServeTLS(*httpsAddr, "/etc/pollen/cert.pem", "/etc/pollen/key.pem", nil))
 }
 
 func fatal(args ...interface{}) {


### PR DESCRIPTION
Feel free to take or leave these changes. I changed the positional arguments to flags and also plumbed the 'bytes' argument all the way through.

I think it's nicer to use flags rather than positional arguments:
- You get some sanity checking for free
- Now there are default arguments (so the man page is accurate)
- You get a nice help message that describes the usage for free

I changed the 'port' arguments to 'addr' arguments so that the user may specify the interface as well (for example, 'localhost:8080' or something if they don't want to listen on a public interface and instead use a reverse proxy in front.
